### PR TITLE
feat: using saved apis

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { ConfigProvider, Layout, Spin, theme } from 'antd'
 import { notification } from 'antd'
 import { onAuthStateChanged } from 'firebase/auth'
-import React, { useCallback, useEffect } from 'react'
+import React, { useEffect } from 'react'
 import styles from './App.module.scss'
 import { ApiConfigModal } from './components/ApiConfigModal/ApiConfigModal'
 import { SettingsModal } from './components/SettingsModal/SettingsModal'
@@ -52,21 +52,23 @@ const App = () => {
 
   } = useMicioStore()
 
-  const handleInitCasualModel = useCallback((config: Record<AIProvider, string>) => {
-    const geminiDefault = ModelsList.find(model => model.name === 'gemini-2.0-flash')
-    const mistralDefault = ModelsList.find(model => model.name === 'mistral-small-latest')
-    const openAiDefault = ModelsList.find(model => model.name === 'gpt-4')
-    const deepSeekDefault = ModelsList.find(model => model.name === 'deepseek-chat')
-    if (config[AIProvider.GEMINI] && geminiDefault) {
-      changeModel(geminiDefault)
-    } else if (config[AIProvider.MISTRAL] && mistralDefault) {
-      changeModel(mistralDefault)
-    } else if (config[AIProvider.DEEPSEEK] && deepSeekDefault) {
-      changeModel(deepSeekDefault)
-    } else if (config[AIProvider.OPENAI] && openAiDefault) {
-      changeModel(openAiDefault)
-    } 
-  }, [])
+  useEffect(() => {
+    if (apisConfig) {
+      const geminiDefault = ModelsList.find(model => model.name === 'gemini-2.0-flash')
+      const mistralDefault = ModelsList.find(model => model.name === 'mistral-small-latest')
+      const openAiDefault = ModelsList.find(model => model.name === 'gpt-4')
+      const deepSeekDefault = ModelsList.find(model => model.name === 'deepseek-chat')
+      if (apisConfig[AIProvider.GEMINI] && geminiDefault) {
+        changeModel(geminiDefault)
+      } else if (apisConfig[AIProvider.MISTRAL] && mistralDefault) {
+        changeModel(mistralDefault)
+      } else if (apisConfig[AIProvider.DEEPSEEK] && deepSeekDefault) {
+        changeModel(deepSeekDefault)
+      } else if (apisConfig[AIProvider.OPENAI] && openAiDefault) {
+        changeModel(openAiDefault)
+      } 
+    }
+  }, [apisConfig])
 
   useEffect(() => {
     if (micionotification) {
@@ -74,7 +76,7 @@ const App = () => {
         message: micionotification.title,
         description: micionotification.description,
         placement: 'bottomLeft' as const,
-        duration: 3,
+        duration: micionotification.type === 'error' ?  6: 3,
         onClick: () => {
           api.destroy()
           clearNotification()
@@ -95,12 +97,6 @@ const App = () => {
       }
     }
   }, [api, clearNotification, micionotification])
-
-  useEffect(() => {
-    if (apisConfig) {
-      handleInitCasualModel(apisConfig)
-    }
-  }, [apisConfig, handleInitCasualModel])
 
   useEffect(() => {
     onAuthStateChanged(auth, async (user) => {
@@ -126,7 +122,9 @@ const App = () => {
           if(checkedUser && !apisConfig) {
             const apisConfig = await getApisConfig()
             console.log('APIS CONFIG', apisConfig)
-            if(apisConfig) setApisConfig(apisConfig)
+            if(apisConfig) {
+              setApisConfig(apisConfig, false)
+            }
             else openConfigModal()
           }
         } catch (error) {
@@ -139,7 +137,6 @@ const App = () => {
           //TODO 
         }
       }
-  
       loadApis()
    }, [checkedUser, apisConfig, setApisConfig, openConfigModal, setNotification])
   

--- a/src/components/ApiConfigModal/ApiConfigModal.tsx
+++ b/src/components/ApiConfigModal/ApiConfigModal.tsx
@@ -27,7 +27,7 @@ export const ApiConfigModal = () => {
 
   const handleSaveApis = async () => {
     await saveApisConfig(apiKeys)
-    setApisConfig(apiKeys)
+    setApisConfig(apiKeys, true)
     closeConfigModal()
   }
 

--- a/src/hooks/providers/useDeepseek.ts
+++ b/src/hooks/providers/useDeepseek.ts
@@ -23,7 +23,7 @@ const useDeepSeek = () => {
 
   const init = () =>  {
     if (!apisConfig) {
-        throw new Error('APIS_CONFIG environment variable is not set.')
+        throw new Error('API configuration is not set.')
       }
     const deepSeekKey = apisConfig[AIProvider.DEEPSEEK]
     const openai = new OpenAI({

--- a/src/hooks/providers/useDeepseek.ts
+++ b/src/hooks/providers/useDeepseek.ts
@@ -3,13 +3,14 @@ import { useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import { Model } from '@/model/ai'
 import { ContentTypes, Message, UploadedFile } from '@/model/chat'
+import { AIProvider } from '@/model/ui'
 import { useMicioStore } from '@/store'
 
 const useDeepSeek = () => {
 
   const {
     chat: {
-      selectedModel, messages,
+      selectedModel, messages, apisConfig,
         actions: { setModel, newAddMessage }
     },
     user: {
@@ -21,7 +22,10 @@ const useDeepSeek = () => {
   const [deepSeekInstance, setDeepSeekInstance] = useState<OpenAI | null>(null)
 
   const init = () =>  {
-    const deepSeekKey = process.env.DEEP_SEEK_KEY
+    if (!apisConfig) {
+        throw new Error('APIS_CONFIG environment variable is not set.')
+      }
+    const deepSeekKey = apisConfig[AIProvider.DEEPSEEK]
     const openai = new OpenAI({
       baseURL: 'https://api.deepseek.com/v1',
       dangerouslyAllowBrowser: true,

--- a/src/hooks/providers/useGemini.ts
+++ b/src/hooks/providers/useGemini.ts
@@ -24,11 +24,11 @@ const useGemini = () => {
 
   const init = () =>  {
     if (!apisConfig) {
-      throw new Error('APIS_CONFIG environment variable is not set.')
+      throw new Error('apisConfig is not defined. Ensure the API configuration is provided.')
     }
     const googleGeminiKey = apisConfig[AIProvider.GEMINI]
     if (!googleGeminiKey) {
-      throw new Error('GOOGLE_GEMINI_KEY environment variable is not set.')
+      throw new Error('GOOGLE_GEMINI_KEY is missing in apisConfig. Ensure the key is correctly configured.')
     }
     const genAI = new GoogleGenAI({ apiKey: googleGeminiKey })
 

--- a/src/hooks/providers/useGemini.ts
+++ b/src/hooks/providers/useGemini.ts
@@ -3,25 +3,30 @@ import { useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import { Model } from '@/model/ai'
 import { ContentTypes, Message, UploadedFile } from '@/model/chat'
+import { AIProvider } from '@/model/ui'
 import { useMicioStore } from '@/store'
 import { GeminiModalitiesByModel } from '@/utils/restrictions'
 
 const useGemini = () => {
 
   const {
-  chat: {
-    currentChat,
-    actions: { setCurrentChat, resetMessages, setModel, newAddMessage }
-  },
-  user: {
-    aiSettings,
-  }
+    chat: {
+      currentChat, apisConfig,
+      actions: { setCurrentChat, resetMessages, setModel, newAddMessage }
+    },
+    user: {
+      aiSettings,
+    },
+  
   } = useMicioStore()
 
   const [geminiInstance, setGeminiInstance] = useState<GoogleGenAI | null>(null)
 
   const init = () =>  {
-    const googleGeminiKey = process.env.GOOGLE_GEMINI_KEY
+    if (!apisConfig) {
+      throw new Error('APIS_CONFIG environment variable is not set.')
+    }
+    const googleGeminiKey = apisConfig[AIProvider.GEMINI]
     if (!googleGeminiKey) {
       throw new Error('GOOGLE_GEMINI_KEY environment variable is not set.')
     }

--- a/src/hooks/providers/useMistral.ts
+++ b/src/hooks/providers/useMistral.ts
@@ -39,7 +39,7 @@ const useMistral = () => {
 
   const init = () =>  {
     if (!apisConfig) {
-      throw new Error('APIS_CONFIG environment variable is not set.')
+      throw new Error('API configuration is missing. Please ensure that the API configuration is properly set.')
     }
     const mistralKey = apisConfig[AIProvider.MISTRAL]
     if (!mistralKey) {

--- a/src/hooks/providers/useMistral.ts
+++ b/src/hooks/providers/useMistral.ts
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import { Model } from '@/model/ai'
 import { ContentTypes, Message, UploadedFile } from '@/model/chat'
+import { AIProvider } from '@/model/ui'
 import { useMicioStore } from '@/store'
 
 enum MistralRoles {
@@ -25,7 +26,7 @@ const useMistral = () => {
 
   const {
     chat: {
-      messages, selectedModel,
+      messages, selectedModel, apisConfig,
       actions: { setModel, newAddMessage }
     },
     user: {
@@ -37,7 +38,10 @@ const useMistral = () => {
 
 
   const init = () =>  {
-    const mistralKey = process.env.MISTRAL_KEY
+    if (!apisConfig) {
+      throw new Error('APIS_CONFIG environment variable is not set.')
+    }
+    const mistralKey = apisConfig[AIProvider.MISTRAL]
     if (!mistralKey) {
         throw new Error('MISTRAL_KEY environment variable is not set.')
     }

--- a/src/hooks/providers/useOpenAi.ts
+++ b/src/hooks/providers/useOpenAi.ts
@@ -22,7 +22,7 @@ const useOpenAi = () => {
   const init = () => {
     
     if (!apisConfig) {
-      throw new Error('APIS_CONFIG environment variable is not set.')
+      throw new Error('API configuration is not set.')
     }
     const openAiKey = apisConfig[AIProvider.OPENAI]
     if (!openAiKey) {

--- a/src/hooks/providers/useOpenAi.ts
+++ b/src/hooks/providers/useOpenAi.ts
@@ -3,12 +3,13 @@ import { useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import { Model } from '@/model/ai'
 import { ContentTypes, Message, UploadedFile } from '@/model/chat'
+import { AIProvider } from '@/model/ui'
 import { useMicioStore } from '@/store'
 
 const useOpenAi = () => {
   const {
     chat: {
-      selectedModel, messages,
+      selectedModel, messages, apisConfig,
       actions: { setModel, newAddMessage }
     },
     user: {
@@ -19,7 +20,11 @@ const useOpenAi = () => {
   const [openAiInstance, setOpenAiInstance] = useState<OpenAI | null>(null)
 
   const init = () => {
-    const openAiKey = process.env.OPEN_AI_KEY
+    
+    if (!apisConfig) {
+      throw new Error('APIS_CONFIG environment variable is not set.')
+    }
+    const openAiKey = apisConfig[AIProvider.OPENAI]
     if (!openAiKey) {
       throw new Error('OPENAI_KEY environment variable is not set.')
     }

--- a/src/hooks/useGenerateContent.ts
+++ b/src/hooks/useGenerateContent.ts
@@ -18,6 +18,11 @@ const useGenerateContent = () => {
     },
     chat: {
       actions: { resetMessages, newAddMessage, setChatUid, restoreMessages }
+    },
+    ui: {
+      actions: {
+        setNotification
+      }
     }
   } = useMicioStore()
 
@@ -74,7 +79,11 @@ const useGenerateContent = () => {
       console.log('Generating content with provider:', currentAiProvider)
       await generateContentFactory[currentAiProvider](statement, uploadedFiles)
     } catch (error) {
-      console.error('Error generating content:', error)
+      setNotification({
+        type: 'error',
+        title: 'Error generating content',
+        description: error instanceof Error ? error.message : 'An unknown error occurred',
+      })
     } finally {
       setIsGenerating(false)
     }

--- a/src/store/slices/chat/index.ts
+++ b/src/store/slices/chat/index.ts
@@ -109,10 +109,17 @@ export const chat = lens<ChatStoreSlice, Store>((set, get, state) => ({
         }
       })
     },
-    setApisConfig: (apisConfig) => {
+    setApisConfig: (apisConfig, manuallySaved) => {
       set((draft) => {
         draft.apisConfig = apisConfig
       })
+      if (manuallySaved) {
+        state.getState().ui.actions.setNotification({
+          type: 'success',
+          title: 'Api key saved',
+          description: 'Your API keys have been saved successfully.',
+        })
+      }
     },
     reset: () => {
       set((draft) => {

--- a/src/store/slices/chat/types.ts
+++ b/src/store/slices/chat/types.ts
@@ -18,7 +18,7 @@ interface Actions {
   // eslint-disable-next-line no-unused-vars
   updateChatList: (chat: MicioChat) => void
   // eslint-disable-next-line no-unused-vars
-  setApisConfig: (apisConfig: Record<AIProvider, string>) => void
+  setApisConfig: (apisConfig: Record<AIProvider, string>, manuallySaved: boolean) => void
   // eslint-disable-next-line no-unused-vars
   deleteChat: (chatId: string) => void
   reset: () => void


### PR DESCRIPTION
## Description

Updating the setApisConfig function signature to accept a new boolean parameter (manuallySaved).
Modifying API provider hooks (OpenAi, Mistral, Gemini, Deepseek) to retrieve API keys from the saved configuration (apisConfig) rather than environment variables.
Adjusting UI notifications and default model initialization in App.tsx based on the updated API configurations.

## Motivation and Context

Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

